### PR TITLE
Update non_interacting.py to improve speed

### DIFF
--- a/iDEA/methods/non_interacting.py
+++ b/iDEA/methods/non_interacting.py
@@ -179,7 +179,7 @@ def add_occupations(
     |     state: iDEA.state.SingleBodyState, State with occupations added.
     """
     # Calculate the max level or orbitals needed to achieve required state and only use these.
-    max_level = (k + 1) * int(np.ceil(s.count))
+    max_level = max(s.up_count,s.down_count) + k
     up_energies = state.up.energies[:max_level]
     down_energies = state.down.energies[:max_level]
 


### PR DESCRIPTION
Corrects the expression for max_level. The maximum level occupied at k=0 is max(s.up_count,s.down_count), and at most 1 new level is occupied with each increment of k, so the maximum level that can be occupied at k=k is max(s.up_count,s.down_count) + k. The current expression for max_level results in too high a value, using energy levels that are not needed - by preventing this, the solve function runs much more quickly:

![Execution Times Solving for the 1st Excited State](https://github.com/LeoArnstein/iDEA/assets/139252533/767c0cb2-e5d4-4861-a27a-0d8bd28cde5b)

